### PR TITLE
Write VRM file with non-interleaved vertex buffers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import {
 	Extension,
 	NodeIO,
 	PropertyType,
+	VertexLayout,
 } from "@gltf-transform/core";
 import { KHRONOS_EXTENSIONS, EXTTextureWebP } from "@gltf-transform/extensions";
 import { existsSync } from "node:fs";
@@ -497,6 +498,7 @@ async function deobfuscateVRoidHubGLB(id) {
 		}
 	}
 
+	io.setVertexLayout(VertexLayout.SEPARATE);
 	const outputGLB = await io.writeBinary(doc);
 	writeFile(`./${id}.deob.vrm`, outputGLB);
 

--- a/src/index.js
+++ b/src/index.js
@@ -455,12 +455,12 @@ async function deobfuscateVRoidHubGLB(id) {
 
 			const dv = new DataView(image.buffer, image.byteOffset, image.byteLength);
 			const magic = dv.getUint32(0);
-			if (magic === 0x8950fe47) {
+			if (magic === 0x89504e47) {
 				console.log("Fixing mime type for PNG", texture.getName());
 				texture.setMimeType("image/png");
 				await writeTexture(texture, "png", image);
 				continue;
-			}else if(magic === 0xffd8ffdb || magic === 0xffd8ffe0 || magic === 0xffd8ffee || magic === 0xffd8ffe1) {
+			} else if(magic === 0xffd8ffdb || magic === 0xffd8ffe0 || magic === 0xffd8ffee || magic === 0xffd8ffe1) {
 				console.log("Fixing mime type for JPEG", texture.getName());
 				texture.setMimeType("image/jpeg");
 				await writeTexture(texture, "jpeg", image, 'jpg');


### PR DESCRIPTION
VRM parsers based on three-vrm have a function `removeUnnecessaryVertices` [which is not supported](https://redirect.github.com/pixiv/three-vrm/pull/1532) on files with interleaved vertex buffers. In practice, a lot of web implementations call this function and then give up altogether when this function fails ([three-vrm's examples](https://pixiv.github.io/three-vrm/packages/three-vrm/examples/), [web 1](https://vrm-viewer-48655.web.app/), [web 2](https://moka-rin.moe/vrm-viewer/))

Our glTF-transform [re-writes vertex buffers](https://redirect.github.com/donmccurdy/glTF-Transform/issues/1137) as interleaved by default, but we can tell it to not do that