### PR TITLE
Preserve samplers as well, to allow models to be imported in blender

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -260,6 +260,8 @@ export class VRMPreservationExtension extends Extension {
 			source: t.source,
 			sampler: t.sampler,
 		}));
+		this.samplers = json.samplers || [];
+
 		return this;
 	}
 
@@ -277,6 +279,7 @@ export class VRMPreservationExtension extends Extension {
 		writeFile("./debug/vrm.json", JSON.stringify(vrmData, null, 2));
 
 		jsonDoc.json.textures = this.textures || [];
+		jsonDoc.json.samplers = this.samplers || [];
 
 		return this;
 	}


### PR DESCRIPTION
Currently, importing the deobfuscated VRM models in Blender fails.

With the error trace ending something like:
```
...
"/Applications/Blender.app/Contents/Resources/4.4/scripts/addons_core/io_scene_gltf2/blender/imp/texture.py", line 31, in texture
    pysampler = mh.gltf.data.samplers[pytexture.sampler]
                ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
IndexError: list index out of range
Location: /Applications/Blender.app/Contents/Resources/4.4/scripts/modules/bpy/ops.py:109
```

This indicated something around the samplers not being present and it seemed like we were not preserving it like we were for textures.

This PR fixes that and the models can now be imported properly in Blender! For research purposes only obviously!