### PR TITLE
Handle obfuscation version v4.0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -141,15 +141,28 @@ class Deobfuscator {
 		const r = this.metaTextureData[index];
 		const g = this.metaTextureData[index + 1];
 		const b = this.metaTextureData[index + 2];
-		return [r / (255 * 16), g / (255 * 16), b / (255 * 16)];
+		return [r / 255, g / 255, b / 255];
 	}
 
-	processVertexDisplacement(accessor, vertexCount, meta, processed) {
+	processVertexDisplacement(accessor, vertexCount, meta, version, processed) {
 		const array = accessor.getArray();
 
-		const adjustComponent = (value, meta) => {
-			return value - Math.sign(value) * meta;
-		};
+		let adjustComponent;
+		switch (version) {
+			case "3.0":
+				adjustComponent = (value, meta) => {
+					return value - Math.sign(value) * meta / 16;
+				};
+				break;
+			case "4.0":
+				adjustComponent = (value, meta) => {
+					return value * (2 ** (meta / 8));
+				};
+				break;
+			default:
+				throw new Error(`Unknown obfuscation version: ${version}`);
+		}
+
 
 		for (let i = 0; i < vertexCount; i++) {
 			const uVal = Math.floor(meta[i * 2] * 256);
@@ -217,6 +230,7 @@ class Deobfuscator {
 					position,
 					vertexCount,
 					meta.getArray(),
+					version,
 					processed,
 				);
 

--- a/src/index.js
+++ b/src/index.js
@@ -427,7 +427,7 @@ export class VRM_v1_node_constraint_Extension extends PreservationExtension {
 
 		this.node_constraint = {};
 		for (let idx in json.nodes) {
-			let node = json.node[idx];
+			let node = json.nodes[idx];
 			if (!node.extensions?.VRMC_node_constraint) continue;
 
 			let ext = node.extensions.VRMC_node_constraint;


### PR DESCRIPTION
Our existing functionality handles obfuscation version 3.0, and here we add support for version 4.0.

It appears that version 4.0 [tends to be used on](https://github.com/uwu/vrh-deobfuscator/pull/14#issuecomment-2822073523) VRM 1.0 files using the `VRMC_node_constraint` subextension - see the link for two examples.