### PR TITLE
fix: rotate vrm scene roots to face forward

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -182,6 +182,61 @@ class RandomGenerator {
 	}
 }
 
+const multiplyQuaternions = (a, b) => {
+	const ax = a[0], ay = a[1], az = a[2], aw = a[3];
+	const bx = b[0], by = b[1], bz = b[2], bw = b[3];
+	return [
+		aw * bx + ax * bw + ay * bz - az * by,
+		aw * by - ax * bz + ay * bw + az * bx,
+		aw * bz + ax * by - ay * bx + az * bw,
+		aw * bw - ax * bx - ay * by - az * bz,
+	];
+};
+
+const rotateVectorByQuaternion = (vec, quat) => {
+	const vx = vec[0], vy = vec[1], vz = vec[2];
+	const qx = quat[0], qy = quat[1], qz = quat[2], qw = quat[3];
+	const uv = [
+		qy * vz - qz * vy,
+		qz * vx - qx * vz,
+		qx * vy - qy * vx,
+	];
+	const uuv = [
+		qy * uv[2] - qz * uv[1],
+		qz * uv[0] - qx * uv[2],
+		qx * uv[1] - qy * uv[0],
+	];
+	return [
+		vx + 2 * (qw * uv[0] + uuv[0]),
+		vy + 2 * (qw * uv[1] + uuv[1]),
+		vz + 2 * (qw * uv[2] + uuv[2]),
+	];
+};
+
+const rotateSceneForward = (doc) => {
+	const flipQuat = [0, 1, 0, 0];
+	const rootNodes = new Set();
+	for (const scene of doc.getRoot().listScenes()) {
+		for (const node of scene.listChildren()) {
+			rootNodes.add(node);
+		}
+	}
+
+	for (const node of rootNodes) {
+		const translation = node.getTranslation();
+		if (translation) {
+			node.setTranslation(rotateVectorByQuaternion(translation, flipQuat));
+		}
+
+		const rotation = node.getRotation();
+		if (rotation) {
+			node.setRotation(multiplyQuaternions(flipQuat, rotation));
+		} else {
+			node.setRotation([...flipQuat]);
+		}
+	}
+};
+
 class Deobfuscator {
 	constructor(seed, version, timestamp) {
 		this.seed = seed;
@@ -772,6 +827,8 @@ async function deobfuscateVRoidHubGLB(id) {
 	
 	const deobfuscator = new Deobfuscator(seed, version, timestamp);
 	deobfuscator.processDocument(doc);
+	// VRoid preview GLBs face +Z; rotate 180° so exported VRMs look toward -Z like Unity/VRM expect.
+	rotateSceneForward(doc);
 
 	const decoder = new KTX2Decoder();
 	const { BasisFile, initializeBasis } = await initialize();


### PR DESCRIPTION
Avatars downloaded were facing the wrong direction.
The fix was created with the help of Codex.