### PR TITLE
Loading cookies from firefox to enable preview. 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,11 @@ import {
 	VertexLayout,
 } from "@gltf-transform/core";
 import { KHRONOS_EXTENSIONS, EXTTextureWebP } from "@gltf-transform/extensions";
-import { existsSync } from "node:fs";
-import { mkdir, writeFile, readFile, unlink, readdir, rm } from "node:fs/promises";
+import { existsSync, readdirSync } from "node:fs";
+import { mkdir, writeFile, readFile, unlink, readdir, rm, copyFile } from "node:fs/promises";
+import { DatabaseSync } from "node:sqlite";
+import os from "node:os";
+import path from "node:path";
 import vm from "node:vm"
 import crypto from "node:crypto";
 import sharp from "sharp";
@@ -694,6 +697,52 @@ export class PIXIVBasisExtension extends Extension {
 	}
 }
 
+// VRoid Hub now gates previews behind login (viewer_preview_usage_level: "login_user"),
+// so anonymous requests to /optimized_preview get a 404. We pull the logged-in session
+// cookie (_vroid_session, scoped to .vroid.com) straight out of the Firefox cookie store.
+async function getVRoidSessionCookie() {
+	const profilesDir = path.join(os.homedir(), "AppData", "Roaming", "Mozilla", "Firefox", "Profiles");
+	if (!existsSync(profilesDir)) return null;
+
+	const tmpDb = path.join(os.tmpdir(), `vrh_cookies_${process.pid}.sqlite`);
+
+	for (const profile of readdirSync(profilesDir)) {
+		const dbPath = path.join(profilesDir, profile, "cookies.sqlite");
+		if (!existsSync(dbPath)) continue;
+
+		// Copy the DB plus its WAL/SHM so recently-written cookies (which may not be
+		// checkpointed into the main file yet) are visible without touching the live store.
+		try {
+			await copyFile(dbPath, tmpDb);
+			for (const ext of ["-wal", "-shm"]) {
+				if (existsSync(dbPath + ext)) await copyFile(dbPath + ext, tmpDb + ext);
+			}
+		} catch {
+			continue;
+		}
+
+		try {
+			const db = new DatabaseSync(tmpDb, { readOnly: true });
+			const row = db
+				.prepare("SELECT value FROM moz_cookies WHERE host LIKE ? AND name = ?")
+				.get("%vroid.com%", "_vroid_session");
+			db.close();
+			if (row?.value) {
+				console.log(`Using VRoid session cookie from Firefox profile: ${profile}`);
+				return `_vroid_session=${row.value}`;
+			}
+		} catch {
+			// fall through to next profile
+		} finally {
+			for (const ext of ["", "-wal", "-shm"]) {
+				await rm(tmpDb + ext, { force: true }).catch(() => {});
+			}
+		}
+	}
+
+	return null;
+}
+
 async function deobfuscateVRoidHubGLB(id) {
 	console.log("Starting deobfuscation process for VRoid Hub GLB...");
 
@@ -725,11 +774,17 @@ async function deobfuscateVRoidHubGLB(id) {
 	} else {
 		console.log(`Fetching VRM data for ID: ${id}...`);
 		
+		const sessionCookie = await getVRoidSessionCookie();
+		if (!sessionCookie) {
+			console.warn("Warning: no VRoid session cookie found in Firefox. Login-gated previews will 404.");
+		}
+
 		const options = {
 			headers: {
 				"X-Api-Version": "11",
 				"User-Agent":
 					"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
+				...(sessionCookie ? { Cookie: sessionCookie } : {}),
 			},
 		};
 		let response = await fetch(`https://hub.vroid.com/api/character_models/${id}/optimized_preview`, options);
@@ -828,7 +883,7 @@ async function deobfuscateVRoidHubGLB(id) {
 	const deobfuscator = new Deobfuscator(seed, version, timestamp);
 	deobfuscator.processDocument(doc);
 	// VRoid preview GLBs face +Z; rotate 180° so exported VRMs look toward -Z like Unity/VRM expect.
-	rotateSceneForward(doc);
+	// rotateSceneForward(doc);
 
 	const decoder = new KTX2Decoder();
 	const { BasisFile, initializeBasis } = await initialize();


### PR DESCRIPTION
Note: I'm running this on windows and haven't tested with other OS.

Vroid requires you to be logged in to show model previews now.

This fix loads cookies from firefox default profile to login so it can download the preview.

ONLY TESTED ON WINDOWS AND FIREFOX

Also #31 doesnt seem to be needed anymore. 
Models were facing the wrong way and faces were inverted, once I commented it out everything was working.

Not removing the code, just in case its needed again for another time or other users.